### PR TITLE
Fix glog command line arguments on a clean build

### DIFF
--- a/build/build_fbzmq.sh
+++ b/build/build_fbzmq.sh
@@ -241,8 +241,8 @@ apt-get install libdouble-conversion-dev \
   python3-setuptools \
   python-pip
 
-install_glog
 install_gflags
+install_glog # Requires gflags to be build first
 install_gtest
 install_mstch
 install_zstd


### PR DESCRIPTION
To support glog's command line arguments like --logtostderr, it requires gflags.

If gflags is not found, glog will still compile but the command line arguments will be absent.

As glog was created before gflags, that was the case on a clean build.
Note that on subsequent builds gflags already existed, so a second build 'magically' made the command line arguments appear.

# Pull Request Template

Title: glog flags like --logtostderr are missing on a clean build

Description:

See https://github.com/facebook/openr/issues/28


Test Plan:
- On my OpenR code I compiled it before and after the reorder, and noticed the different behavior.
- No additional testing was performed for this fbzmq fix.

# Pull Request Guideline

- Before sending a pull request make sure each commit solves one clear, minimal,
  plausible problem. Further each commit should have the above format.
- Please avoid sending a pull request with recursive merge nodes, as they
  are impossible to fix once merged. Please rebase your branch on
  facebook/openr master instead of merging it.
- If you are a new contributor please have a look at our contributing guidelines:
[CONTRIBUTING](https://github.com/facebook/fbzmq/CONTRIBUTING.md)
