### PR TITLE
Fix compilation with newer GCC

### DIFF
--- a/fbzmq/zmq/Message.cpp
+++ b/fbzmq/zmq/Message.cpp
@@ -35,7 +35,7 @@ Message::allocate(size_t size) noexcept {
   if (rc != 0) {
     return folly::makeUnexpected(Error());
   }
-  return std::move(msg);
+  return msg;
 }
 
 folly::Expected<Message, Error>
@@ -58,7 +58,7 @@ Message::wrapBuffer(std::unique_ptr<folly::IOBuf> buf) noexcept {
     delete ptr;
     return folly::makeUnexpected(Error());
   }
-  return std::move(msg);
+  return msg;
 }
 
 Message&

--- a/fbzmq/zmq/Socket.cpp
+++ b/fbzmq/zmq/Socket.cpp
@@ -577,7 +577,7 @@ SocketImpl::recv(int flags) const noexcept {
   while (true) {
     const int n = zmq_msg_recv(&(msg.msg_), ptr_, flags);
     if (n >= 0) {
-      return std::move(msg);
+      return msg;
     }
 
     const int err = zmq_errno();


### PR DESCRIPTION
error: redundant move in return statement [-Werror=redundant-move]