### PR TITLE
[CMake] Add cmake_minimum_required Version

### DIFF
--- a/fbzmq/CMakeLists.txt
+++ b/fbzmq/CMakeLists.txt
@@ -9,6 +9,8 @@
 # Generate thrift defs for C++ only. For python install via setuptools
 #
 
+cmake_minimum_required(VERSION 3.2)
+
 add_fbthrift_cpp_library(
   monitor_cpp2
   service/if/Monitor.thrift


### PR DESCRIPTION
https://cmake.org/cmake/help/latest/command/cmake_minimum_required.html

Add CMake `cmake_minimum_required` to `CMakeLists.txt` to silent
warning.

Description:
Trying to fix the [OpenR](https://github.com/facebook/openr) github workflow, I see following warning from the `fbzmq` build:

```
CMake Warning (dev) in CMakeLists.txt:                                                                                                                                          
  No cmake_minimum_required command is present.  A line of code such as                                                                                                         
                                                                                                                                                                                
    cmake_minimum_required(VERSION 3.10)                                                                                                                                        
                                                                                                                                                                                
  should be added at the top of the file.  The version specified may be lower
  if you wish to support older CMake versions for this project.  For more
  information run "cmake --help-policy CMP0000".
This warning is for project developers.  Use -Wno-dev to suppress it.   
                                                                          
-- Configuring incomplete, errors occurred!
See also "/usr/local/src/fbzmq/fbzmq/build/CMakeFiles/CMakeOutput.log".
```

The minimum version was taken from OpenR (https://github.com/facebook/openr/blob/master/CMakeLists.txt#L8).