### PR TITLE
Added support for markdown-autodocs

### DIFF
--- a/.github/workflows/markdown-autodocs.yml
+++ b/.github/workflows/markdown-autodocs.yml
@@ -1,0 +1,14 @@
+name: markdown-autodocs
+
+on:
+  push:
+    branches:    
+      - '**'        # matches every branch
+
+jobs:        
+  auto-update-readme:
+      runs-on: ubuntu-latest
+      steps:
+        - uses: actions/checkout@v2
+        - name: Markdown autodocs
+          uses: dineshsonachalam/markdown-autodocs@v1.0.2

--- a/README.md
+++ b/README.md
@@ -17,50 +17,8 @@ awesomeness of `libzmq` (message passing semantics). At a high level it provides
 Here is a simple example demonstrating some powerful abstractions of `fbzmq`
 which makes writing asynchronous applications easier on top of `libzmq`
 
-```cpp
-// Create context
-fbzmq::Context context{1};
-
-// Create eventloop
-fbzmq::ZmqEventLoop evl;
-
-// Create thrift serializer
-apache::thrift::CompactSerializer serializer;
-
-// Create REP and PUB server sockets
-fbzmq::Socket<ZMQ_REP, ZMQ_SERVER> reqSocket;
-fbzmq::Socket<ZMQ_PUB, ZMQ_SERVER> pubSocket;
-reqSocket.bind("tcp://[::1]:12345");
-pubSocket.bind("tcp://[::1]:12346");
-
-// Attach callback on reqSocket
-evl.addSocket(RawZmqSocketPtr{*reqSocket}, ZMQ_POLLIN, [&](int evts) noexcept {
-  // It must be POLLIN event
-  CHECK(evts | ZMQ_POLLIN);
-
-  // Read request
-  auto request = reqSocket.recvThriftObj<thrift::Request>(serializer);
-
-  // Send response
-  thrift::Response response;
-  response.request = request;
-  response.success = true;
-  reqSocket.sendThriftObj(response, serializer);
-});
-
-// Create periodic timeout to send publications and schedule it every 10s
-auto timeout = fbzmq::ZmqTimeout::make(&evl, [&]() noexcept {
-  thrift::User user;
-  user.name = "TestPerson";
-  user.email = "test@person.com";
-  pubSocket.sendThriftObj(nodeData, serializer);
-});
-timeout->scheduleTimeout(std::chrono::seconds(10), true /* periodic */);
-
-// Let the magic begin
-evl.run()
-
-```
+<!-- MARKDOWN-AUTO-DOCS:START (CODE:src=./examples/app.cpp) -->
+<!-- MARKDOWN-AUTO-DOCS:END -->
 
 ## Requirements
 We have tried `fbzmq` on `Ubuntu-14.04`, `Ubuntu-16.04` and `CentOS-7`. This

--- a/README.md
+++ b/README.md
@@ -18,6 +18,50 @@ Here is a simple example demonstrating some powerful abstractions of `fbzmq`
 which makes writing asynchronous applications easier on top of `libzmq`
 
 <!-- MARKDOWN-AUTO-DOCS:START (CODE:src=./examples/app.cpp) -->
+<!-- The below code snippet is automatically added from ./examples/app.cpp -->
+```cpp
+// Create context
+fbzmq::Context context{1};
+
+// Create eventloop
+fbzmq::ZmqEventLoop evl;
+
+// Create thrift serializer
+apache::thrift::CompactSerializer serializer;
+
+// Create REP and PUB server sockets
+fbzmq::Socket<ZMQ_REP, ZMQ_SERVER> reqSocket;
+fbzmq::Socket<ZMQ_PUB, ZMQ_SERVER> pubSocket;
+reqSocket.bind("tcp://[::1]:12345");
+pubSocket.bind("tcp://[::1]:12346");
+
+// Attach callback on reqSocket
+evl.addSocket(RawZmqSocketPtr{*reqSocket}, ZMQ_POLLIN, [&](int evts) noexcept {
+  // It must be POLLIN event
+  CHECK(evts | ZMQ_POLLIN);
+
+  // Read request
+  auto request = reqSocket.recvThriftObj<thrift::Request>(serializer);
+
+  // Send response
+  thrift::Response response;
+  response.request = request;
+  response.success = true;
+  reqSocket.sendThriftObj(response, serializer);
+});
+
+// Create periodic timeout to send publications and schedule it every 10s
+auto timeout = fbzmq::ZmqTimeout::make(&evl, [&]() noexcept {
+  thrift::User user;
+  user.name = "TestPerson";
+  user.email = "test@person.com";
+  pubSocket.sendThriftObj(nodeData, serializer);
+});
+timeout->scheduleTimeout(std::chrono::seconds(10), true /* periodic */);
+
+// Let the magic begin
+evl.run()
+```
 <!-- MARKDOWN-AUTO-DOCS:END -->
 
 ## Requirements

--- a/examples/app.cpp
+++ b/examples/app.cpp
@@ -1,0 +1,41 @@
+// Create context
+fbzmq::Context context{1};
+
+// Create eventloop
+fbzmq::ZmqEventLoop evl;
+
+// Create thrift serializer
+apache::thrift::CompactSerializer serializer;
+
+// Create REP and PUB server sockets
+fbzmq::Socket<ZMQ_REP, ZMQ_SERVER> reqSocket;
+fbzmq::Socket<ZMQ_PUB, ZMQ_SERVER> pubSocket;
+reqSocket.bind("tcp://[::1]:12345");
+pubSocket.bind("tcp://[::1]:12346");
+
+// Attach callback on reqSocket
+evl.addSocket(RawZmqSocketPtr{*reqSocket}, ZMQ_POLLIN, [&](int evts) noexcept {
+  // It must be POLLIN event
+  CHECK(evts | ZMQ_POLLIN);
+
+  // Read request
+  auto request = reqSocket.recvThriftObj<thrift::Request>(serializer);
+
+  // Send response
+  thrift::Response response;
+  response.request = request;
+  response.success = true;
+  reqSocket.sendThriftObj(response, serializer);
+});
+
+// Create periodic timeout to send publications and schedule it every 10s
+auto timeout = fbzmq::ZmqTimeout::make(&evl, [&]() noexcept {
+  thrift::User user;
+  user.name = "TestPerson";
+  user.email = "test@person.com";
+  pubSocket.sendThriftObj(nodeData, serializer);
+});
+timeout->scheduleTimeout(std::chrono::seconds(10), true /* periodic */);
+
+// Let the magic begin
+evl.run()


### PR DESCRIPTION
## Problem with updating  Code block or Markdown tables in your README.md 

To make your repo more appealing and, useful you need to provide example code snippets in your README.md. Manually copy and pasting each code snippet or adding a table row in their respective places in your README would be inefficient and time-consuming.

## Solution to this problem:

This problem can be solved using markdown-autodocs GitHub Action that is created by me that automatically generates & updates markdown content (like your README.md) from external or remote files. You need to add markers in your README.md that will tell markdown-autodocs where to insert the code snippet or transform JSON to HTML table.

Markdown Autodocs GitHub action: https://github.com/dineshsonachalam/markdown-autodocs

To test or experiment markdown-autodocs without Github action: https://github.com/dineshsonachalam/markdown-autodocs#local-usage-without-github-action

Please let me know if any changes are required and will be happy to help.

