### PR TITLE
fix anon-struct usage that's a warning/error -Wnon-c-typedef-for-linkage (#137)

### DIFF
--- a/fbzmq/zmq/SocketMonitor.h
+++ b/fbzmq/zmq/SocketMonitor.h
@@ -88,7 +88,7 @@ class SocketMonitor {
   /**
    * event object passed down the PAIR socket to monitor class
    */
-  using EventT = struct {
+  struct EventT {
     uint16_t event;
     int32_t data;
   };


### PR DESCRIPTION
Summary:
X-link: https://github.com/facebook/CacheLib/pull/137

Fix
  error: anonymous non-C-compatible type given name for linkage purposes by alias declaration; add a tag name here [-Werror,-Wnon-c-typedef-for-linkage]

Reviewed By: philippv

Differential Revision: D36043476

